### PR TITLE
feat(codemodel): Add JavaScript and TypeScript structure providers

### DIFF
--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptClassStructureProvider.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptClassStructureProvider.kt
@@ -1,0 +1,51 @@
+package com.phodal.shirelang.javascript.codemodel
+
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.openapi.application.runReadAction
+import com.intellij.psi.*
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.phodal.shirecore.codemodel.ClassStructureProvider
+import com.phodal.shirecore.codemodel.model.ClassStructure
+
+class JavaScriptClassStructureProvider : ClassStructureProvider {
+    override fun build(psiElement: PsiElement, gatherUsages: Boolean): ClassStructure? {
+        when (psiElement) {
+            is JSClass -> {
+                val methods: List<PsiElement> = psiElement.functions.toList()
+                val fields: List<PsiElement> = psiElement.fields.toList()
+
+                val usages =
+                    if (gatherUsages) findUsages(psiElement as PsiNameIdentifierOwner) else emptyList()
+
+                val supers = psiElement.supers
+                val superClasses = supers.filterIsInstance<JSClass>().mapNotNull { it.name }
+
+                val annotations: List<String> = mutableListOf()
+
+                return ClassStructure(
+                    psiElement,
+                    psiElement.text,
+                    psiElement.name,
+                    displayName = runReadAction { psiElement.qualifiedName },
+                    methods,
+                    fields,
+                    superClasses,
+                    annotations,
+                    usages
+                )
+            }
+            else -> return null
+        }
+    }
+
+    companion object {
+        fun findUsages(psiElement: PsiElement): List<PsiReference> {
+            val globalSearchScope = GlobalSearchScope.allScope(psiElement.project)
+
+            return ReferencesSearch.search(psiElement, globalSearchScope, true)
+                .findAll()
+                .toList()
+        }
+    }
+}

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptFileStructureProvider.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptFileStructureProvider.kt
@@ -1,0 +1,31 @@
+package com.phodal.shirelang.javascript.codemodel
+
+import com.intellij.lang.ecmascript6.psi.impl.ES6ImportPsiUtil
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.phodal.shirecore.codemodel.FileStructureProvider
+import com.phodal.shirecore.codemodel.model.FileStructure
+
+class JavaScriptFileStructureProvider : FileStructureProvider {
+    override fun build(psiFile: PsiFile): FileStructure? {
+        val file = psiFile.virtualFile ?: return null
+        val importDeclarations = ES6ImportPsiUtil.getImportDeclarations((psiFile as PsiElement))
+        val classes =
+            PsiTreeUtil.getChildrenOfTypeAsList(psiFile as PsiElement, JSClass::class.java)
+        val functions =
+            PsiTreeUtil.getChildrenOfTypeAsList(psiFile as PsiElement, JSFunction::class.java)
+
+        return FileStructure(
+            psiFile,
+            psiFile.name,
+            file.path,
+            null,
+            importDeclarations,
+            classes,
+            functions
+        )
+    }
+}

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptMethodStructureProvider.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptMethodStructureProvider.kt
@@ -1,0 +1,32 @@
+package com.phodal.shirelang.javascript.codemodel
+
+import com.intellij.lang.javascript.presentable.JSFormatUtil
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.JSType
+import com.intellij.lang.javascript.psi.util.JSUtils
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNameIdentifierOwner
+import com.phodal.shirecore.codemodel.MethodStructureProvider
+import com.phodal.shirecore.codemodel.model.MethodStructure
+
+class JavaScriptMethodStructureProvider : MethodStructureProvider {
+    override fun build(psiElement: PsiElement, includeClassContext: Boolean, gatherUsages: Boolean): MethodStructure? {
+        if (psiElement !is JSFunction) return null
+
+        val functionSignature = JSFormatUtil.buildFunctionSignaturePresentation(psiElement)
+        val containingClass: PsiElement? = JSUtils.getMemberContainingClass(psiElement)
+        val languageDisplayName = psiElement.language.displayName
+        val returnType = psiElement.returnType
+        val returnTypeText = returnType?.substitute()?.getTypeText(JSType.TypeTextFormat.CODE)
+
+        val parameterNames = psiElement.parameters.mapNotNull { it.name }
+
+        val usages =
+            if (gatherUsages) JavaScriptClassStructureProvider.findUsages(psiElement as PsiNameIdentifierOwner) else emptyList()
+
+        return MethodStructure(
+            psiElement, psiElement.text, psiElement.name!!, functionSignature, containingClass, languageDisplayName,
+            returnTypeText, parameterNames, includeClassContext, usages
+        )
+    }
+}

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptVariableStructureProvider.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codemodel/JavaScriptVariableStructureProvider.kt
@@ -1,0 +1,43 @@
+package com.phodal.shirelang.javascript.codemodel
+
+import com.intellij.lang.javascript.psi.JSFieldVariable
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.util.JSUtils
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNameIdentifierOwner
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.PsiTreeUtil
+import com.phodal.shirecore.codemodel.VariableStructureProvider
+import com.phodal.shirecore.codemodel.model.VariableStructure
+
+class JavaScriptVariableStructureProvider : VariableStructureProvider {
+    override fun build(
+        psiElement: PsiElement,
+        withMethodContext: Boolean,
+        withClassContext: Boolean,
+        gatherUsages: Boolean
+    ): VariableStructure? {
+        if (psiElement !is JSFieldVariable) {
+            return null
+        }
+
+        val parentOfType: PsiElement? = PsiTreeUtil.getParentOfType(psiElement, JSFunction::class.java, true)
+        val memberContainingClass: PsiElement = JSUtils.getMemberContainingClass(psiElement)
+        val psiReferences: List<PsiReference> = if (gatherUsages) {
+            JavaScriptClassStructureProvider.findUsages(psiElement as PsiNameIdentifierOwner)
+        } else {
+            emptyList()
+        }
+
+        return VariableStructure(
+            psiElement,
+            psiElement.text,
+            psiElement.name!!,
+            parentOfType,
+            memberContainingClass,
+            psiReferences,
+            withMethodContext,
+            withClassContext
+        )
+    }
+}

--- a/languages/shire-javascript/src/main/resources/com.phodal.shirelang.javascript.xml
+++ b/languages/shire-javascript/src/main/resources/com.phodal.shirelang.javascript.xml
@@ -4,6 +4,26 @@
         <plugin id="JavaScript"/>
     </dependencies>
     <extensions defaultExtensionNs="com.phodal">
+        <classStructureProvider language="JavaScript"
+                                implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptClassStructureProvider"/>
+        <classStructureProvider language="TypeScript"
+                                implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptClassStructureProvider"/>
+
+        <fileStructureProvider language="JavaScript"
+                               implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptFileStructureProvider"/>
+        <fileStructureProvider language="TypeScript"
+                               implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptFileStructureProvider"/>
+
+        <methodStructureProvider language="JavaScript"
+                                 implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptMethodStructureProvider"/>
+        <methodStructureProvider language="TypeScript"
+                                 implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptMethodStructureProvider"/>
+
+        <variableStructureProvider language="JavaScript"
+                                   implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptVariableStructureProvider"/>
+        <variableStructureProvider language="TypeScript"
+                                   implementationClass="com.phodal.shirelang.javascript.codemodel.JavaScriptVariableStructureProvider"/>
+
         <shireLanguageToolchainProvider language="TypeScript"
                                         implementationClass="com.phodal.shirelang.javascript.variable.JavaScriptLanguageToolchainProvider"/>
         <shireRefactoringTool
@@ -12,5 +32,6 @@
 
         <shireBuildSystemProvider
                 implementation="com.phodal.shirelang.javascript.impl.JavaScriptBuildSystemProvider"/>
+
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Implements providers for class, file, method, and variable structures. These enhancements enable better support for JavaScript and TypeScript code analysis within the IDE, allowing for improved refactoring and tooling.

diff:
- Adds new structure provider classes for JavaScript and TypeScript.
- Updates plugin configuration to include the new providers.