### PR TITLE
feat(javascript): add JestCodeModifier and JSAutoTestingService

### DIFF
--- a/core/src/main/kotlin/com/phodal/shirecore/provider/TestingService.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/TestingService.kt
@@ -1,5 +1,6 @@
 package com.phodal.shirecore.provider
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -7,6 +8,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.serviceContainer.LazyExtensionInstance
 import com.intellij.util.xmlb.annotations.Attribute
+import com.phodal.shirecore.codemodel.model.ClassStructure
 import com.phodal.shirecore.provider.shire.FileRunService
 import com.phodal.shirecore.variable.toolchain.unittest.AutoTestingPromptContext
 
@@ -50,9 +52,9 @@ abstract class TestingService : LazyExtensionInstance<TestingService>(), FileRun
      *
      * @param project the project in which to perform the lookup
      * @param element the element for which to find the relevant classes
-     * @return a list of ClassContext objects representing the relevant classes found in the project
+     * @return a list of ClassStructure objects representing the relevant classes found in the project
      */
-    abstract fun lookupRelevantClass(project: Project, element: PsiElement): List<String>
+    abstract fun lookupRelevantClass(project: Project, element: PsiElement): List<ClassStructure>
 
     /**
      * This method is used to collect syntax errors from a given project and write them to an output file.
@@ -79,6 +81,7 @@ abstract class TestingService : LazyExtensionInstance<TestingService>(), FileRun
     }
 
     companion object {
+        val log = logger<TestingService>()
         private val EP_NAME: ExtensionPointName<TestingService> =
             ExtensionPointName.create("com.phodal.shireAutoTesting")
 

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codeedit/JSAutoTestingService.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codeedit/JSAutoTestingService.kt
@@ -1,0 +1,272 @@
+package com.phodal.shirelang.javascript.codeedit
+
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.lang.javascript.buildTools.npm.rc.NpmRunConfiguration
+import com.intellij.lang.javascript.psi.JSFile
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.JSVarStatement
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptInterface
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.lang.javascript.psi.ecmal4.JSImportStatement
+import com.intellij.lang.javascript.psi.util.JSStubBasedPsiTreeUtil
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.phodal.shirecore.codemodel.model.ClassStructure
+import com.phodal.shirecore.provider.TestingService
+import com.phodal.shirecore.variable.toolchain.unittest.AutoTestingPromptContext
+import com.phodal.shirelang.javascript.codemodel.JavaScriptClassStructureProvider
+import com.phodal.shirelang.javascript.codemodel.JavaScriptMethodStructureProvider
+import com.phodal.shirelang.javascript.util.JSPsiUtil
+import com.phodal.shirelang.javascript.util.LanguageApplicableUtil
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+class JSAutoTestingService : TestingService() {
+    private val log = logger<JSAutoTestingService>()
+    override fun runConfigurationClass(project: Project): Class<out RunProfile> = NpmRunConfiguration::class.java
+
+    override fun isApplicable(element: PsiElement): Boolean {
+        val sourceFile: PsiFile = element.containingFile ?: return false
+        return LanguageApplicableUtil.isWebChatCreationContextSupported(sourceFile)
+    }
+
+    override fun findOrCreateTestFile(
+        sourceFile: PsiFile,
+        project: Project,
+        psiElement: PsiElement
+    ): AutoTestingPromptContext? {
+        val language = sourceFile.language
+        val testFilePath = Util.getTestFilePath(psiElement)?.toString()
+        if (testFilePath == null) {
+            log.warn("Failed to find test file path for: $psiElement")
+            return null
+        }
+
+        val elementToTest = runReadAction { Util.getElementToTest(psiElement) }
+        if (elementToTest == null) {
+            log.warn("Failed to find element to test for: ${psiElement}, check your function is exported.")
+            return null
+        }
+
+        val elementName = JSPsiUtil.elementName(elementToTest)
+        if (elementName == null) {
+            log.warn("Failed to find element name for: $psiElement")
+            return null
+        }
+
+        var testFile = LocalFileSystem.getInstance().findFileByPath(testFilePath)
+        if (testFile != null) {
+            return AutoTestingPromptContext(false, testFile, emptyList(), null, language, null)
+        }
+
+        WriteCommandAction.writeCommandAction(sourceFile.project).withName("Generate Unit Tests")
+            .compute<Unit, Throwable> {
+                val parentDir = VfsUtil.createDirectoryIfMissing(Path(testFilePath).parent.toString())
+                testFile = parentDir?.createChildData(this, Path(testFilePath).fileName.toString())
+            }
+
+        val underTestObj = ReadAction.compute<String, Throwable> {
+            val underTestObj = JavaScriptClassStructureProvider()
+                .build(elementToTest, false)?.format()
+
+            if (underTestObj == null) {
+                val funcObj = JavaScriptMethodStructureProvider()
+                    .build(elementToTest, false, false)?.format()
+
+                return@compute funcObj ?: ""
+            } else {
+                return@compute underTestObj
+            }
+        }
+
+        val imports: List<String> = (sourceFile as? JSFile)?.let {
+            PsiTreeUtil.findChildrenOfType(it, JSImportStatement::class.java)
+        }?.map {
+            it.text
+        } ?: emptyList()
+
+        return AutoTestingPromptContext(true, testFile!!, emptyList(), elementName, language, underTestObj, imports)
+    }
+
+    override fun lookupRelevantClass(project: Project, element: PsiElement): List<ClassStructure> {
+        return ReadAction.compute<List<ClassStructure>, Throwable> {
+            val elements = mutableListOf<ClassStructure>()
+            when (element) {
+                is JSClass -> {
+                    element.functions.map {
+                        elements += resolveByFunction(it).values
+                    }
+                }
+
+                is JSFunction -> {
+                    elements += resolveByFunction(element).values
+                }
+
+                else -> {}
+            }
+
+            return@compute elements
+        }
+    }
+
+    private fun resolveByFunction(jsFunction: JSFunction): Map<String, ClassStructure> {
+        val result = mutableMapOf<String, ClassStructure>()
+        jsFunction.parameterList?.parameters?.map {
+            it.typeElement?.let { typeElement ->
+                result += resolveByType(typeElement, it.typeElement!!.text)
+            }
+        }
+
+        result += jsFunction.returnTypeElement?.let {
+            resolveByType(it, jsFunction.returnType!!.resolvedTypeText)
+        } ?: emptyMap()
+
+        return result
+    }
+
+    private fun resolveByType(
+        returnType: PsiElement?,
+        typeName: String
+    ): MutableMap<String, ClassStructure> {
+        val result = mutableMapOf<String, ClassStructure>()
+        when (returnType) {
+            is TypeScriptSingleType -> {
+                val resolveReferenceLocally = JSStubBasedPsiTreeUtil.resolveLocally(
+                    typeName,
+                    returnType
+                )
+
+                when (resolveReferenceLocally) {
+                    is TypeScriptInterface -> {
+                        JavaScriptClassStructureProvider().build(resolveReferenceLocally, false)?.let {
+                            result += mapOf(typeName to it)
+                        }
+                    }
+
+                    else -> {
+                        log.warn("resolveReferenceLocally is not TypeScriptInterface: $resolveReferenceLocally")
+                    }
+                }
+            }
+
+            else -> {
+                log.warn("returnType is not TypeScriptSingleType: $returnType")
+            }
+        }
+
+        return result
+    }
+
+    object Util {
+        /**
+         * In JavaScript/TypeScript a testable element is a function, a class or a variable.
+         *
+         * Function:
+         * ```javascript
+         * function testableFunction() {}
+         * export testableFunction
+         * ```
+         *
+         * Class:
+         * ```javascript
+         * export class TestableClass {}
+         * ```
+         *
+         * Variable:
+         * ```javascript
+         * var functionA = function() {}
+         * export functionA
+         * ```
+         */
+        fun getElementToTest(psiElement: PsiElement): PsiElement? {
+            val jsFunc = PsiTreeUtil.getParentOfType(psiElement, JSFunction::class.java, false)
+            val jsVarStatement = PsiTreeUtil.getParentOfType(psiElement, JSVarStatement::class.java, false)
+            val jsClazz = PsiTreeUtil.getParentOfType(psiElement, JSClass::class.java, false)
+
+            val elementForTests: PsiElement? = when {
+                jsFunc != null -> jsFunc
+                jsVarStatement != null -> jsVarStatement
+                jsClazz != null -> jsClazz
+                else -> null
+            }
+
+            if (elementForTests == null) return null
+
+            return when {
+                JSPsiUtil.isExportedClassPublicMethod(elementForTests) -> elementForTests
+                JSPsiUtil.isExportedFileFunction(elementForTests) -> elementForTests
+                JSPsiUtil.isExportedClass(elementForTests) -> elementForTests
+                else -> {
+                    null
+                }
+            }
+        }
+
+        fun getTestFilePath(element: PsiElement): Path? {
+            val testDirectory = suggestTestDirectory(element)
+            if (testDirectory == null) {
+                log.warn("Failed to find test directory for: $element")
+                return null
+            }
+
+            val containingFile: PsiFile = runReadAction { element.containingFile } ?: return null
+            val extension = containingFile.virtualFile?.extension ?: return null
+            val elementName = JSPsiUtil.elementName(element) ?: return null
+            val testFile: Path = generateUniqueTestFile(elementName, containingFile, testDirectory, extension).toPath()
+            return testFile
+        }
+
+        /**
+         * Todo: since in JavaScript has different test framework, we need to find the test directory by the framework.
+         */
+        private fun suggestTestDirectory(element: PsiElement): PsiDirectory? =
+            ReadAction.compute<PsiDirectory?, Throwable> {
+                val project: Project = element.project
+                val elementDirectory = element.containingFile
+
+                val parentDir = elementDirectory?.virtualFile?.parent ?: return@compute null
+                val psiManager = PsiManager.getInstance(project)
+
+                val findDirectory = psiManager.findDirectory(parentDir)
+                if (findDirectory != null) {
+                    return@compute findDirectory
+                }
+
+                val createChildDirectory = parentDir.createChildDirectory(this, "test")
+                return@compute psiManager.findDirectory(createChildDirectory)
+            }
+
+        private fun generateUniqueTestFile(
+            elementName: String?,
+            containingFile: PsiFile,
+            testDirectory: PsiDirectory,
+            extension: String
+        ): File {
+            val testPath = testDirectory.virtualFile.path
+            val prefix = elementName ?: containingFile.name.substringBefore('.', "")
+            val nameCandidate = "$prefix.test.$extension"
+            var testFile = File(testPath, nameCandidate)
+
+            var i = 1
+            while (testFile.exists()) {
+                val nameCandidateWithIndex = "$prefix${i}.test.$extension"
+                i++
+                testFile = File(testPath, nameCandidateWithIndex)
+            }
+
+            return testFile
+        }
+    }
+}

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codeedit/JavaScriptTestCodeModifier.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codeedit/JavaScriptTestCodeModifier.kt
@@ -1,0 +1,60 @@
+package com.phodal.shirelang.javascript.codeedit
+
+import com.intellij.lang.Language
+import com.intellij.lang.javascript.psi.JSFile
+import com.intellij.lang.javascript.psi.impl.JSPsiElementFactory
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiManager
+import com.phodal.shirecore.provider.codeedit.CodeModifier
+import com.phodal.shirelang.javascript.util.LanguageApplicableUtil
+
+open class JavaScriptTestCodeModifier : CodeModifier {
+    override fun isApplicable(language: Language): Boolean {
+        return LanguageApplicableUtil.isJavaScriptApplicable(language)
+    }
+
+    override fun smartInsert(
+        sourceFile: VirtualFile,
+        project: Project,
+        code: String
+    ): PsiElement? {
+        TODO("Not yet implemented")
+    }
+
+    override fun insertTestCode(sourceFile: VirtualFile, project: Project, code: String): PsiElement? {
+        val isExit = sourceFile as? JSFile
+        if (isExit == null) {
+            return insertClass(sourceFile, project, code)
+        }
+
+        return insertMethod(sourceFile, project, code)
+    }
+
+    override fun insertMethod(sourceFile: VirtualFile, project: Project, code: String): PsiElement? {
+        // todo: spike for insert different method type, like named function, arrow function, etc.
+        val jsFile = PsiManager.getInstance(project).findFile(sourceFile) as JSFile
+        val psiElement = jsFile.lastChild
+
+        val element = PsiFileFactory.getInstance(project).createFileFromText(jsFile.language, "")
+        val codeElement = JSPsiElementFactory.createJSStatement(code, element)
+
+        return runReadAction {
+            psiElement?.parent?.addAfter(codeElement, psiElement)
+        }
+    }
+
+    override fun insertClass(sourceFile: VirtualFile, project: Project, code: String): PsiElement? {
+        return WriteCommandAction.runWriteCommandAction<PsiElement?>(project) {
+            val psiFile = PsiManager.getInstance(project).findFile(sourceFile) as JSFile
+            val document = psiFile.viewProvider.document!!
+            document.insertString(document.textLength, code)
+            psiFile.lastChild
+        }
+    }
+
+}

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codeedit/JestCodeModifier.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/codeedit/JestCodeModifier.kt
@@ -1,0 +1,10 @@
+package com.phodal.shirelang.javascript.codeedit
+
+import com.intellij.lang.Language
+import com.phodal.shirelang.javascript.util.LanguageApplicableUtil
+
+class JestCodeModifier : JavaScriptTestCodeModifier() {
+    override fun isApplicable(language: Language): Boolean {
+        return LanguageApplicableUtil.isJavaScriptApplicable(language)
+    }
+}

--- a/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/util/JSPsiUtil.kt
+++ b/languages/shire-javascript/src/main/kotlin/com/phodal/shirelang/javascript/util/JSPsiUtil.kt
@@ -1,0 +1,181 @@
+package com.phodal.shirelang.javascript.util
+
+import com.intellij.lang.ecmascript6.psi.ES6ExportDeclaration
+import com.intellij.lang.ecmascript6.psi.ES6ExportDefaultAssignment
+import com.intellij.lang.javascript.frameworks.commonjs.CommonJSUtil
+import com.intellij.lang.javascript.psi.*
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptGenericOrMappedTypeParameter
+import com.intellij.lang.javascript.psi.ecmal4.JSAttributeList
+import com.intellij.lang.javascript.psi.ecmal4.JSAttributeListOwner
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.lang.javascript.psi.ecmal4.JSQualifiedNamedElement
+import com.intellij.lang.javascript.psi.resolve.JSResolveResult
+import com.intellij.lang.javascript.psi.stubs.JSImplicitElement
+import com.intellij.lang.javascript.psi.util.JSDestructuringUtil
+import com.intellij.lang.javascript.psi.util.JSStubBasedPsiTreeUtil
+import com.intellij.lang.javascript.psi.util.JSUtils
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parents
+import com.phodal.shirecore.project.isInProject
+
+object JSPsiUtil {
+    fun resolveReference(node: JSReferenceExpression, scope: PsiElement): PsiElement? {
+        val resolveReference = JSResolveResult.resolveReference(node)
+        var resolved = resolveReference.firstOrNull() as? JSImplicitElement
+
+        if (resolved != null) {
+            resolved = resolved.parent as? JSImplicitElement
+        }
+
+        if (resolved is JSFunction && resolved.isConstructor) {
+            resolved = JSUtils.getMemberContainingClass(resolved) as? JSImplicitElement
+        }
+
+        if (resolved == null || skipDeclaration(resolved)) {
+            return null
+        }
+
+        val virtualFile = resolved.containingFile?.virtualFile
+
+        if (virtualFile == null ||
+            !node.project.isInProject(virtualFile) ||
+            ProjectFileIndex.getInstance(node.project).isInLibrary(virtualFile)
+        ) {
+            return JSStubBasedPsiTreeUtil.resolveReferenceLocally(node as PsiPolyVariantReference, node.referenceName)
+        }
+
+        val jSImplicitElement = resolved
+
+        return if (jSImplicitElement.textLength == 0 || !PsiTreeUtil.isAncestor(scope, jSImplicitElement, true)) {
+            jSImplicitElement
+        } else {
+            null
+        }
+    }
+
+    private fun skipDeclaration(element: PsiElement): Boolean {
+        return when (element) {
+            is JSParameter, is TypeScriptGenericOrMappedTypeParameter -> true
+            is JSField -> {
+                element.initializerOrStub !is JSFunctionExpression
+            }
+
+            is JSVariable -> {
+                var initializer = JSDestructuringUtil.getNearestDestructuringInitializer(element)
+                if (initializer == null) {
+                    initializer = element.initializerOrStub ?: return true
+                }
+
+                !(initializer is JSCallExpression
+                        || initializer is JSFunctionExpression
+                        || initializer is JSObjectLiteralExpression
+                        )
+            }
+
+            else -> false
+        }
+    }
+
+
+    fun isExportedFileFunction(element: PsiElement): Boolean {
+        when (val parent = element.parent) {
+            is JSFile, is JSEmbeddedContent -> {
+                return when (element) {
+                    is JSVarStatement -> {
+                        val variables = element.variables
+                        val variable = variables.firstOrNull() ?: return false
+                        variable.initializerOrStub is JSFunction && exported(variable)
+                    }
+
+                    is JSFunction -> exported(element)
+                    else -> false
+                }
+            }
+
+            is JSVariable -> {
+                val varStatement = parent.parent as? JSVarStatement ?: return false
+                return varStatement.parent is JSFile && exported(parent)
+            }
+
+            else -> {
+                return parent is ES6ExportDefaultAssignment
+            }
+        }
+    }
+
+    fun isExportedClass(elementForTests: PsiElement?): Boolean {
+        return elementForTests is JSClass && elementForTests.isExported
+    }
+
+    fun isExportedClassPublicMethod(psiElement: PsiElement): Boolean {
+        val jsClass = PsiTreeUtil.getParentOfType(psiElement, JSClass::class.java, true) ?: return false
+        if (!exported(jsClass as PsiElement)) return false
+
+        val parentElement = psiElement.parents(true).firstOrNull() ?: return false
+        if (isPrivateMember(parentElement)) return false
+
+        return when (parentElement) {
+            is JSFunction -> !parentElement.isConstructor
+            is JSVarStatement -> {
+                val variables = parentElement.variables
+                val jSVariable = variables.firstOrNull()
+                (jSVariable?.initializerOrStub as? JSFunction) != null
+            }
+
+            else -> false
+        }
+    }
+
+    private fun exported(element: PsiElement): Boolean {
+        if (element !is JSElementBase) return false
+
+        if (element.isExported || element.isExportedWithDefault) {
+            return true
+        }
+
+        if (element is JSPsiElementBase && CommonJSUtil.isExportedWithModuleExports(element)) {
+            return true
+        }
+
+        val containingFile = element.containingFile ?: return false
+        val exportDeclarations =
+            PsiTreeUtil.getChildrenOfTypeAsList(containingFile, ES6ExportDeclaration::class.java)
+
+        return exportDeclarations.any { exportDeclaration ->
+            exportDeclaration.exportSpecifiers
+                .asSequence()
+                .any { it.alias?.findAliasedElement() == element }
+        }
+    }
+
+    fun elementName(psiElement: PsiElement): String? {
+        if (psiElement !is JSVarStatement) {
+            if (psiElement !is JSNamedElement) return null
+
+            return psiElement.name
+        }
+
+        val jSVariable = psiElement.variables.firstOrNull() ?: return null
+        return jSVariable.name
+    }
+
+    /**
+     * Determines whether the given [element] is a private member.
+     *
+     * @param element the PSI element to check
+     * @return `true` if the element is a private member, `false` otherwise
+     */
+    private fun isPrivateMember(element: PsiElement): Boolean {
+        if (element is JSQualifiedNamedElement && element.isPrivateName) {
+            return true
+        }
+
+        if (element !is JSAttributeListOwner) return false
+
+        val attributeList = element.attributeList
+        return attributeList?.accessType == JSAttributeList.AccessType.PRIVATE
+    }
+}

--- a/languages/shire-javascript/src/main/resources/com.phodal.shirelang.javascript.xml
+++ b/languages/shire-javascript/src/main/resources/com.phodal.shirelang.javascript.xml
@@ -33,5 +33,15 @@
         <shireBuildSystemProvider
                 implementation="com.phodal.shirelang.javascript.impl.JavaScriptBuildSystemProvider"/>
 
+        <shireCodeModifier language="JavaScript"
+                           implementationClass="com.phodal.shirelang.javascript.codeedit.JestCodeModifier"/>
+        <shireCodeModifier language="TypeScript"
+                           implementationClass="com.phodal.shirelang.javascript.codeedit.JestCodeModifier"/>
+
+        <shireAutoTesting language="JavaScript"
+                          implementationClass="com.phodal.shirelang.javascript.codeedit.JSAutoTestingService"/>
+        <shireAutoTesting language="TypeScript"
+                          implementationClass="com.phodal.shirelang.javascript.codeedit.JSAutoTestingService"/>
+
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Add new Kotlin classes JestCodeModifier and JSAutoTestingService to enhance JavaScript and TypeScript testing capabilities within the project. These classes provide utility functions for code modification and automated testing, respectively. Additionally, updates were made to the TestingService interface to support the new testing service and to the plugin configuration file to include the new providers.