### PR TITLE
fix(runner): LlmProvider is still working after canceling the shire p…

### DIFF
--- a/core/src/main/kotlin/com/phodal/shirecore/config/interaction/task/ShireInteractionTask.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/config/interaction/task/ShireInteractionTask.kt
@@ -1,8 +1,10 @@
 package com.phodal.shirecore.config.interaction.task
 
+import com.intellij.execution.ui.ConsoleView
 import com.intellij.openapi.progress.Task.Backgroundable
 import com.intellij.openapi.project.Project
 import com.phodal.shirecore.config.interaction.PostFunction
+import com.phodal.shirecore.console.addCancelCallback
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -20,3 +22,6 @@ abstract class ShireInteractionTask(project: Project, taskName: String, val post
     }
 
 }
+
+fun ShireInteractionTask.cancelWithConsole(consoleView: ConsoleView?): ShireInteractionTask =
+    apply { consoleView?.addCancelCallback { onCancel() } }

--- a/core/src/main/kotlin/com/phodal/shirecore/console/CustomFlowWrapper.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/console/CustomFlowWrapper.kt
@@ -1,0 +1,47 @@
+package com.phodal.shirecore.console
+
+import com.intellij.execution.ui.ConsoleView
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.cancellable
+
+/**
+ * This class supports cancel callback for [Flow],
+ * the flow consumer cancels the flow collection after callback is called,
+ * which can be used to skip processing useless data.
+ *
+ * @author lk
+ */
+class CustomFlowWrapper<T>(private val delegate: Flow<T>) : Flow<T> {
+
+    private var isCanceled = false
+
+    private var _cancelCallback: ((String) -> Unit)? = null
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        if (!isCanceled) {
+            delegate.collect(collector)
+        }
+    }
+
+    fun cancelCallback(callback: (String) -> Unit) {
+        _cancelCallback = callback
+    }
+
+    fun cancel(message: String) {
+        check(isCanceled == false) { "This flow has been canceled" }
+        isCanceled = true
+        _cancelCallback?.invoke(message)
+    }
+}
+
+
+fun <T> Flow<T>.cancelWithConsole(consoleView: ConsoleView?): Flow<T> =
+    cancelHandler { consoleView?.addCancelCallback(it) }
+
+/**
+ * Please use [CustomFlowWrapper] to call it and it won't work if it's CancellableFlow,
+ * so you need to call it before calling [cancellable]
+ */
+fun <T> Flow<T>.cancelHandler(handle: ((String) -> Unit) -> Unit): Flow<T> =
+    apply { if (this is CustomFlowWrapper<T>) handle({ cancel(it) }) }

--- a/core/src/main/kotlin/com/phodal/shirecore/console/ShireConsoleViewBase.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/console/ShireConsoleViewBase.kt
@@ -1,0 +1,32 @@
+package com.phodal.shirecore.console
+
+import com.intellij.execution.console.ConsoleViewWrapperBase
+import com.intellij.execution.ui.ConsoleView
+
+/**
+ * This class provides cancel callbacks for the console view
+ * and stop the tasks related to it when it is closed,
+ *
+ * @author lk
+ */
+open class ShireConsoleViewBase(executionConsole: ConsoleView) : ConsoleViewWrapperBase(executionConsole) {
+
+    open fun cancelCallback(callback: (String) -> Unit) = Unit
+
+    open fun isCanceled() = false
+
+}
+
+fun ConsoleView.addCancelCallback(callback: (String) -> Unit) {
+    if (this is ShireConsoleViewBase) {
+        cancelCallback(callback)
+    }
+}
+
+fun ConsoleView.isCanceled(): Boolean {
+    if (this is ShireConsoleViewBase) {
+        return isCanceled()
+    }
+    return false
+}
+

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/compiler/hobbit/HobbitHole.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/compiler/hobbit/HobbitHole.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.phodal.shirecore.config.ShireActionLocation
 import com.phodal.shirecore.config.InteractionType
+import com.phodal.shirecore.console.isCanceled
 import com.phodal.shirecore.middleware.PostProcessorContext
 import com.phodal.shirecore.middleware.PostProcessor
 import com.phodal.shirecore.middleware.PostProcessorFuncSign
@@ -234,6 +235,7 @@ open class HobbitHole(
     ): String? {
         console?.print("\n", ConsoleViewContentType.SYSTEM_OUTPUT)
         onStreamingEnd.forEach { funcNode ->
+            if (console?.isCanceled() == true) return@forEach
             console?.print("endExecute: ${funcNode.funName}\n", ConsoleViewContentType.SYSTEM_OUTPUT)
             val postProcessor = PostProcessor.handler(funcNode.funName)
             if (postProcessor == null) {
@@ -272,6 +274,7 @@ open class HobbitHole(
         console: ConsoleView?,
         context: PostProcessorContext,
     ): Any? {
+        if (console?.isCanceled() == true) return null
         val result = afterStreaming?.execute(myProject, context, this)
         context.lastTaskOutput = result as? String
         return result

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/run/executor/CustomRemoteAgentLlmExecutor.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/run/executor/CustomRemoteAgentLlmExecutor.kt
@@ -8,6 +8,7 @@ import com.phodal.shirelang.ShireBundle
 import com.phodal.shirelang.run.flow.ShireConversationService
 import com.phodal.shirecore.ShireCoroutineScope
 import com.phodal.shirecore.config.interaction.PostFunction
+import com.phodal.shirecore.console.cancelWithConsole
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -34,7 +35,7 @@ class CustomRemoteAgentLlmExecutor(
             ShireCoroutineScope.scope(context.myProject).launch {
                 val llmResult = StringBuilder()
                 runBlocking {
-                    stringFlow.collect {
+                    stringFlow.cancelWithConsole(console).collect {
                         llmResult.append(it)
                         console?.print(it, ConsoleViewContentType.NORMAL_OUTPUT)
                     }

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/run/executor/ShireDefaultLlmExecutor.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/run/executor/ShireDefaultLlmExecutor.kt
@@ -7,6 +7,7 @@ import com.phodal.shirecore.ShireCoroutineScope
 import com.phodal.shirecore.config.InteractionType
 import com.phodal.shirecore.config.ShireActionLocation
 import com.phodal.shirecore.config.interaction.PostFunction
+import com.phodal.shirecore.console.cancelWithConsole
 import com.phodal.shirecore.llm.LlmProvider
 import com.phodal.shirecore.provider.ide.LocationInteractionContext
 import com.phodal.shirecore.provider.ide.LocationInteractionProvider
@@ -61,7 +62,8 @@ class ShireDefaultLlmExecutor(
                 val llmResult = StringBuilder()
                 runBlocking {
                     try {
-                        LlmProvider.provider(context.myProject)?.stream(context.prompt, "", false)?.collect {
+                        LlmProvider.provider(context.myProject)?.stream(context.prompt, "", false)
+                            ?.cancelWithConsole(console)?.collect {
                             llmResult.append(it)
                             console?.print(it, ConsoleViewContentType.NORMAL_OUTPUT)
                         } ?: console?.print(

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/run/flow/ShireConversationService.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/run/flow/ShireConversationService.kt
@@ -3,6 +3,7 @@ package com.phodal.shirelang.run.flow
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import com.phodal.shirecore.console.cancelWithConsole
 import com.phodal.shirecore.llm.LlmProvider
 import com.phodal.shirelang.ShireBundle
 import com.phodal.shirelang.compiler.ShireParsedResult
@@ -79,6 +80,7 @@ class ShireConversationService(val project: Project) {
                 try {
                     LlmProvider.provider(project)
                         ?.stream(finalPrompt, "", true)
+                        ?.cancelWithConsole(consoleView)
                         ?.collect {
                             consoleView.print(it, ConsoleViewContentType.NORMAL_OUTPUT)
                         }

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/run/flow/ShireProcessProcessor.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/run/flow/ShireProcessProcessor.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.util.PsiUtilBase
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.phodal.shirecore.llm.LlmProvider
 import com.phodal.shirecore.ShirelangNotifications
+import com.phodal.shirecore.console.cancelWithConsole
 import com.phodal.shirecore.middleware.select.SelectElementStrategy
 import com.phodal.shirelang.ShireLanguage
 import com.phodal.shirelang.compiler.ShireSyntaxAnalyzer
@@ -104,7 +105,7 @@ class ShireProcessProcessor(val project: Project) {
 
             runBlocking {
                 try {
-                    LlmProvider.provider(project)?.stream(result.shireOutput, "Shirelang", true)?.collect {
+                    LlmProvider.provider(project)?.stream(result.shireOutput, "Shirelang", true)?.cancelWithConsole(consoleView)?.collect {
                             consoleView.print(it, ConsoleViewContentType.NORMAL_OUTPUT)
                         }
                 } catch (e: Exception) {


### PR DESCRIPTION
After canceling the shire process, it was found that the coroutines related to it were still running, and it could be seen that it was still outputting data, which actually does a lot of useless processing.

For example, I found this situation using `RunPanel` and `InsertBeforeSelection`

When the user cancels the shire process, it should stop working to avoid affecting its use.