### PR TITLE
refactor(actions): ActionCache supports dynamic updates without resta…

### DIFF
--- a/shirelang/src/main/kotlin/com/phodal/shirelang/actions/ShireFileChangesProvider.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/actions/ShireFileChangesProvider.kt
@@ -1,0 +1,124 @@
+package com.phodal.shirelang.actions
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileDocumentManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.AsyncFileListener
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.events.VFileCopyEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
+import com.intellij.psi.PsiManager
+import com.phodal.shirelang.compiler.hobbit.HobbitHole
+import com.phodal.shirelang.psi.ShireFile
+
+/**
+ * It is used after the project is started
+ * and can use [shireFileModifier] to handle shire file change events.
+ *
+ * @author lk
+ */
+@Service(Service.Level.PROJECT)
+class ShireFileChangesProvider(val project: Project) : Disposable {
+
+    @Volatile
+    var shireFileModifier: ShireFileModifier? = null
+
+    fun startup(afterUpdater: (HobbitHole, ShireFile) -> Unit) {
+        (shireFileModifier ?: synchronized(this) {
+            shireFileModifier ?: ShireFileModifier(project, afterUpdater).also { shireFileModifier = it }
+        }).startup()
+
+    }
+
+    fun onUpdated(file: ShireFile) {
+        ShireUpdater.publisher.onUpdated { file }
+    }
+
+    companion object {
+
+        fun getInstance(project: Project): ShireFileChangesProvider {
+            return project.getService(ShireFileChangesProvider::class.java)
+        }
+
+    }
+
+    override fun dispose() {
+        shireFileModifier?.dispose()
+    }
+}
+
+internal class ShireFileModifcationListener : FileDocumentManagerListener, DocumentListener, ShireFileListener {
+
+    fun onUpdated(document: Document) {
+        FileDocumentManager.getInstance().getFile(document).let { onUpdated(it) }
+    }
+
+    override fun documentChanged(event: DocumentEvent) {
+        onUpdated(event.document)
+    }
+
+    override fun bulkUpdateFinished(document: Document) {
+        onUpdated(document)
+    }
+
+    override fun unsavedDocumentDropped(document: Document) {
+        onUpdated(document)
+    }
+
+}
+
+internal class AsyncShireFileListener : AsyncFileListener, ShireFileListener {
+
+    override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier {
+
+        val beforeChangedEvents = mutableListOf<VFileEvent>()
+        val afterChangedEvents = mutableListOf<VFileEvent>()
+        for (event in events) {
+            if (event is VFileDeleteEvent) beforeChangedEvents.add(event)
+            if (event is VFileCopyEvent || event is VFileMoveEvent) afterChangedEvents.add(event)
+        }
+
+        return object : AsyncFileListener.ChangeApplier {
+            override fun beforeVfsChange() {
+                beforeChangedEvents.forEach { onUpdated(it.file) }
+            }
+
+            override fun afterVfsChange() {
+                afterChangedEvents.forEach {
+                    when (it) {
+                        is VFileCopyEvent -> {
+                            onUpdated(it.findCreatedFile())
+                        }
+
+                        else -> {
+                            onUpdated(it.file)
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+
+}
+
+/**
+ * Only handle events related to shire file
+ */
+interface ShireFileListener {
+
+    fun onUpdated(file: VirtualFile?) {
+        if (file == null || !file.isValid) return
+        ShireUpdater.publisher.onUpdated {
+            PsiManager.getInstance(it).findFile(file) as? ShireFile
+        }
+    }
+}

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/actions/ShireFileModifier.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/actions/ShireFileModifier.kt
@@ -1,0 +1,115 @@
+package com.phodal.shirelang.actions
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBusConnection
+import com.intellij.util.messages.Topic
+import com.phodal.shirecore.ShireCoroutineScope
+import com.phodal.shirelang.actions.base.DynamicShireActionConfig
+import com.phodal.shirelang.actions.base.DynamicShireActionService
+import com.phodal.shirelang.compiler.hobbit.HobbitHole
+import com.phodal.shirelang.compiler.parser.HobbitHoleParser
+import com.phodal.shirelang.psi.ShireFile
+import kotlinx.coroutines.*
+import java.util.concurrent.TimeUnit
+
+/**
+ * This class is provided to ShireFileChangesProvider to dynamically adjust
+ * the shire action config when the content of the shire file changes.
+ *
+ * It supports delayed processing([delayTime]) to avoid duplicate updates as much as possible.
+ *
+ * @author lk
+ */
+class ShireFileModifier(val project: Project, val afterUpdater: ((HobbitHole, ShireFile) -> Unit)?) {
+
+    private val dynamicShireActionService: DynamicShireActionService = DynamicShireActionService.getInstance()
+
+    private val queue: MutableSet<ShireFile> = mutableSetOf()
+
+    private val waitingUpdateQueue: ArrayDeque<ShireFile> = ArrayDeque()
+
+    private val delayTime: Long = TimeUnit.SECONDS.toMillis(3)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = Dispatchers.IO.limitedParallelism(1)
+
+    @Volatile
+    var connect: MessageBusConnection? = null
+
+    fun modify(afterUpdater: ((HobbitHole, ShireFile) -> Unit)?) {
+        ShireCoroutineScope.scope(project).launch(dispatcher) {
+            delay(delayTime)
+            synchronized(queue) {
+                waitingUpdateQueue.addAll(queue)
+                queue.clear()
+            }
+            runBlocking {
+                waitingUpdateQueue.forEach { file ->
+                    if (!file.isValid) {
+                        dynamicShireActionService.removeAction(file)
+                        logger.debug("Shire file[${file.name}] is deleted")
+                        return@forEach
+                    }
+                    if (!file.isPhysical) return@forEach
+                    try {
+                        HobbitHoleParser.parse(file)?.let {
+                            dynamicShireActionService.putAction(file, DynamicShireActionConfig(it.name, it, file))
+                            afterUpdater?.invoke(it, file)
+                            logger.debug("Shire action[${it.name}] is loaded")
+                        }
+                    } catch (e: Exception) {
+                        logger.warn("An error occurred while parsing shire file: ${file.virtualFile.path}", e)
+                    }
+                }
+            }
+            waitingUpdateQueue.clear()
+        }
+    }
+
+    fun startup() {
+        connect ?: synchronized(this) {
+            connect ?: ShireUpdater.register { it.invoke(project)?.let { add(it) } }.also { connect = it }
+        }
+
+    }
+
+    fun add(file: ShireFile) {
+        synchronized(queue) {
+            queue.add(file)
+        }
+        modify(afterUpdater)
+    }
+
+    fun dispose() {
+        connect?.dispose()
+    }
+
+    companion object {
+
+        private val logger = logger<ShireFileModifier>()
+
+    }
+}
+
+
+fun interface ShireUpdater {
+
+    fun onUpdated(processor: (Project) -> ShireFile?)
+
+    companion object {
+
+        @Topic.ProjectLevel
+        val TOPIC: Topic<ShireUpdater> = Topic.create("shire file updated", ShireUpdater::class.java)
+
+        val publisher: ShireUpdater
+            get() = ApplicationManager.getApplication().messageBus.syncPublisher(TOPIC)
+
+        fun register(subscriber: ShireUpdater): MessageBusConnection {
+            val connection = ApplicationManager.getApplication().messageBus.connect()
+            connection.subscribe(TOPIC, subscriber)
+            return connection
+        }
+    }
+}

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/actions/base/DynamicShireActionService.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/actions/base/DynamicShireActionService.kt
@@ -7,14 +7,18 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.keymap.KeymapManager
 import com.phodal.shirecore.config.ShireActionLocation
+import com.phodal.shirelang.psi.ShireFile
+import java.util.*
 
 @Service(Service.Level.APP)
 class DynamicShireActionService {
-    private val actionCache = mutableMapOf<String, DynamicShireActionConfig>()
+    private val actionCache = WeakHashMap<ShireFile, DynamicShireActionConfig>()
 
-    fun putAction(key: String, action: DynamicShireActionConfig) {
+    fun putAction(key: ShireFile, action: DynamicShireActionConfig) {
         actionCache[key] = action
     }
+
+    fun removeAction(key: ShireFile) = actionCache.keys.removeIf{ key === it }
 
     fun getAllActions(): List<DynamicShireActionConfig> = actionCache.values.toList()
 

--- a/shirelang/src/main/resources/com.phodal.shirelang.xml
+++ b/shirelang/src/main/resources/com.phodal.shirelang.xml
@@ -70,6 +70,13 @@
         </intentionAction>
 
         <copyPastePreProcessor implementation="com.phodal.shirelang.actions.copyPaste.ShireCopyPastePreProcessor"/>
+
+        <vfs.asyncListener implementation="com.phodal.shirelang.actions.AsyncShireFileListener"/>
+
+        <fileDocumentManagerListener implementation="com.phodal.shirelang.actions.ShireFileModifcationListener"/>
+
+        <editorFactoryDocumentListener implementation="com.phodal.shirelang.actions.ShireFileModifcationListener"/>
+
     </extensions>
 
     <actions>


### PR DESCRIPTION
**`actionCache`** cannot be updated with the Shire file update, and after updating the shire file, an unexpected errors occurred when using the shire service, If I want to use the latest configuration, I need to restart the IDE.
			
Related events: `document changed`, `add file`, `copy file`, `delete file`, `move file`...
For example, add a shire file with **actionLocation** set to `ContextMenu`，the action would not show in Context Menu by Right Click until I restart the ide.

When the user makes changes to the shire file, the latest configuration should be used without restarting the IDE, but there may be actions with the duplicate name.

Do duplicate name checks when editing shire files in the future?
Is this **`actionCache`** shared by multiple projects?

Also resolved many ReadCancellationException that occurred when starting the shire plugin.