### PR TITLE
Fixed some issues

### DIFF
--- a/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/ClassStructureProvider.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/ClassStructureProvider.kt
@@ -1,6 +1,5 @@
 package com.phodal.shirecore.provider.codemodel
 
-import com.intellij.lang.Language
 import com.intellij.lang.LanguageExtension
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.psi.PsiElement
@@ -23,23 +22,15 @@ interface ClassStructureProvider {
 
     companion object {
         private val languageExtension = LanguageExtension<ClassStructureProvider>("com.phodal.classStructureProvider")
-        private val providers: List<ClassStructureProvider>
+        private val providers: Map<String, ClassStructureProvider> = StructureProvider.loadProviders(languageExtension)
         private val logger = logger<ClassStructureProvider>()
 
-        init {
-            val registeredLanguages = Language.getRegisteredLanguages()
-            providers = registeredLanguages.mapNotNull(languageExtension::forLanguage)
-        }
-
         fun from(psiElement: PsiElement, gatherUsages: Boolean = false): ClassStructure? {
-            for (provider in providers) {
-                try {
-                    return provider.build(psiElement, gatherUsages)
-                } catch (e: Exception) {
-                    logger.error("Error while getting class context from $provider", e)
-                }
+            try {
+                return providers[psiElement.language.id]?.build(psiElement, gatherUsages)
+            } catch (e: Exception) {
+                logger.error("Error while getting class context from", e)
             }
-
             return null
         }
     }

--- a/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/FileStructureProvider.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/FileStructureProvider.kt
@@ -1,6 +1,5 @@
 package com.phodal.shirecore.provider.codemodel
 
-import com.intellij.lang.Language
 import com.intellij.lang.LanguageExtension
 import com.intellij.psi.PsiFile
 import com.phodal.shirecore.provider.codemodel.model.FileStructure
@@ -10,22 +9,11 @@ interface FileStructureProvider {
 
     companion object {
         private val languageExtension = LanguageExtension<FileStructureProvider>("com.phodal.fileStructureProvider")
-        private val providers: List<FileStructureProvider>
-
-        init {
-            val registeredLanguages = Language.getRegisteredLanguages()
-            providers = registeredLanguages.mapNotNull(languageExtension::forLanguage)
-        }
+        private val providers: Map<String, FileStructureProvider> = StructureProvider.loadProviders(languageExtension)
 
         fun from(psiFile: PsiFile): FileStructure {
-            for (provider in providers) {
-                val fileContext = provider.build(psiFile)
-                if (fileContext != null) {
-                    return fileContext
-                }
-            }
-
-            return FileStructure(psiFile, psiFile.name, psiFile.virtualFile.path)
+            return providers[psiFile.language.id]?.build(psiFile)
+                ?: FileStructure(psiFile, psiFile.name, psiFile.virtualFile.path)
         }
     }
 }

--- a/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/MethodStructureProvider.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/MethodStructureProvider.kt
@@ -1,6 +1,5 @@
 package com.phodal.shirecore.provider.codemodel
 
-import com.intellij.lang.Language
 import com.intellij.lang.LanguageExtension
 import com.intellij.psi.PsiElement
 import com.phodal.shirecore.provider.codemodel.model.MethodStructure
@@ -15,24 +14,11 @@ interface MethodStructureProvider {
 
     companion object {
         private val languageExtension = LanguageExtension<MethodStructureProvider>("com.phodal.methodStructureProvider")
-        private val providers: List<MethodStructureProvider>
-
-        init {
-            val registeredLanguages = Language.getRegisteredLanguages()
-            providers = registeredLanguages.mapNotNull(languageExtension::forLanguage)
-        }
+        private val providers: Map<String, MethodStructureProvider> = StructureProvider.loadProviders(languageExtension)
 
         fun from(psiElement: PsiElement, includeClassContext: Boolean = false, gatherUsages: Boolean = false): MethodStructure? {
-            val iterator = providers.iterator()
-            while (iterator.hasNext()) {
-                val provider = iterator.next()
-                val methodContext = provider.build(psiElement, includeClassContext, gatherUsages)
-                if (methodContext != null) {
-                    return methodContext
-                }
-            }
-
-            return MethodStructure(psiElement, psiElement.text, null)
+            return providers[psiElement.language.id]?.build(psiElement, includeClassContext, gatherUsages)
+                ?: MethodStructure(psiElement, psiElement.text, null)
         }
     }
 }

--- a/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/StructureProvider.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/StructureProvider.kt
@@ -1,0 +1,24 @@
+package com.phodal.shirecore.provider.codemodel
+
+import com.intellij.lang.Language
+import com.intellij.lang.LanguageExtension
+
+/**
+ * @author lk
+ */
+object StructureProvider {
+
+    private val registeredLanguages = Language.getRegisteredLanguages()
+
+    /**
+     * Load providers for different StructureProviders
+     * and return specific providers based on the language.
+     */
+    fun <T> loadProviders(languageExtension: LanguageExtension<T>): Map<String, T> {
+        return registeredLanguages.mapNotNull {
+            languageExtension.forLanguage(it)?.run {
+                it.id to this
+            }
+        }.toMap()
+    }
+}

--- a/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/VariableStructureProvider.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/codemodel/VariableStructureProvider.kt
@@ -1,6 +1,5 @@
 package com.phodal.shirecore.provider.codemodel
 
-import com.intellij.lang.Language
 import com.intellij.lang.LanguageExtension
 import com.intellij.psi.PsiElement
 import com.phodal.shirecore.provider.codemodel.model.VariableStructure
@@ -16,12 +15,7 @@ interface VariableStructureProvider {
     companion object {
         private val languageExtension =
             LanguageExtension<VariableStructureProvider>("com.phodal.variableStructureProvider")
-        private val providers: List<VariableStructureProvider>
-
-        init {
-            val registeredLanguages = Language.getRegisteredLanguages()
-            providers = registeredLanguages.mapNotNull(languageExtension::forLanguage)
-        }
+        private val providers: Map<String, VariableStructureProvider> = StructureProvider.loadProviders(languageExtension)
 
         fun from(
             psiElement: PsiElement,
@@ -29,14 +23,8 @@ interface VariableStructureProvider {
             includeClassContext: Boolean = false,
             gatherUsages: Boolean = false,
         ): VariableStructure {
-            for (provider in providers) {
-                val variableStructure =
-                    provider.build(psiElement, includeMethodContext, includeClassContext, gatherUsages) ?: continue
-
-                return variableStructure
-            }
-
-            return VariableStructure(psiElement, psiElement.text, null)
+            return providers[psiElement.language.id]?.build(psiElement, includeMethodContext, includeClassContext, gatherUsages)
+                ?: VariableStructure(psiElement, psiElement.text, null)
         }
     }
 

--- a/core/src/main/kotlin/com/phodal/shirecore/runner/console/CustomFlowWrapper.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/runner/console/CustomFlowWrapper.kt
@@ -40,7 +40,7 @@ fun <T> Flow<T>.cancelWithConsole(consoleView: ConsoleView?): Flow<T> =
     cancelHandler { consoleView?.addCancelCallback(it) }
 
 /**
- * Please use [CustomFlowWrapper] to call it and it won't work if it's CancellableFlow,
+ * Please use [CustomFlowWrapper] to call it, and it won't work if it's CancellableFlow,
  * so you need to call it before calling [cancellable]
  */
 fun <T> Flow<T>.cancelHandler(handle: ((String) -> Unit) -> Unit): Flow<T> =

--- a/languages/shire-java/src/main/kotlin/com/phodal/shirelang/java/variable/JavaPsiContextVariableProvider.kt
+++ b/languages/shire-java/src/main/kotlin/com/phodal/shirelang/java/variable/JavaPsiContextVariableProvider.kt
@@ -4,8 +4,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.testIntegration.TestFinderHelper
-import com.phodal.shirecore.provider.context.LanguageToolchainProvider
-import com.phodal.shirecore.provider.context.ToolchainPrepareContext
 import com.phodal.shirecore.provider.variable.impl.CodeSmellBuilder
 import com.phodal.shirecore.provider.variable.model.PsiContextVariable
 import com.phodal.shirecore.provider.variable.PsiContextVariableProvider
@@ -15,13 +13,12 @@ import com.phodal.shirelang.java.codemodel.JavaClassStructureProvider
 import com.phodal.shirelang.java.util.JavaTestHelper
 import com.phodal.shirelang.java.util.getContainingClass
 import com.phodal.shirelang.java.variable.provider.JavaRelatedClassesProvider
-import kotlinx.coroutines.runBlocking
 
 class JavaPsiContextVariableProvider : PsiContextVariableProvider {
     override fun resolve(variable: PsiContextVariable, project: Project, editor: Editor, psiElement: PsiElement?): Any {
         if (psiElement?.language?.id != "JAVA") return ""
 
-        val clazz: PsiClass? = psiElement.getContainingClass()
+        val clazz: PsiClass? = psiElement as? PsiClass ?: psiElement.getContainingClass()
         val sourceFile: PsiJavaFile = psiElement.containingFile as PsiJavaFile
 
         return when (variable) {

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/actions/base/DynamicShireActionService.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/actions/base/DynamicShireActionService.kt
@@ -30,7 +30,6 @@ class DynamicShireActionService: DynamicActionService {
     override fun getAllActions(): List<DynamicShireActionConfig> {
         return (actionCache.values.toList() + dynamicActionService.getAllActions())
             .distinctBy { it.shireFile.virtualFile }
-            .distinctBy { it.name }
     }
 
     fun getActions(location: ShireActionLocation): List<DynamicShireActionConfig> {

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/actions/context/ShireContextMenuActionGroup.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/actions/context/ShireContextMenuActionGroup.kt
@@ -1,11 +1,9 @@
 package com.phodal.shirelang.actions.context
 
-import com.intellij.openapi.actionSystem.ActionGroup
-import com.intellij.openapi.actionSystem.ActionUpdateThread
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.*
 import com.phodal.shirecore.config.ShireActionLocation
 import com.phodal.shirelang.actions.base.DynamicShireActionService
+import com.phodal.shirelang.actions.base.validator.WhenConditionValidator
 
 class ShireContextMenuActionGroup : ActionGroup() {
     override fun getActionUpdateThread(): ActionUpdateThread {
@@ -25,13 +23,18 @@ class ShireContextMenuActionGroup : ActionGroup() {
             if (actionConfig.hole == null) return@mapNotNull null
             if (!actionConfig.hole.enabled) return@mapNotNull null
 
+            actionConfig.hole.when_?.let {
+                val psiFile = e.getData(CommonDataKeys.PSI_FILE) ?: return@mapNotNull null
+                if (!WhenConditionValidator.isAvailable(it, psiFile)) return@mapNotNull null
+            }
+
             val menuAction = ShireContextMenuAction(actionConfig)
             if (actionConfig.hole.shortcut != null) {
                 actionService.bindShortcutToAction(menuAction, actionConfig.hole.shortcut)
             }
 
             menuAction
-        }.toTypedArray()
+        }.distinctBy { it.templatePresentation.text }.toTypedArray()
     }
 }
 


### PR DESCRIPTION

- Cannot get currentClassName variable when psiElement type is PsiClass.

- SSE parsing exception caused the shire process to not stop, such as `UnknownHost` and  `SocketTimeout`.

- Improve the logic of duplicate names for dynamic actions in the context menu.
   For example, these two shire configurations with the same name should not be filtered, they can be used in specific places
 ```
---
name: "hobbit"  
actionLocation: ContextMenu
when: $fileName.contains(".kt")
---
 ```
 ```
---
name: "hobbit"  
actionLocation: ContextMenu
when: $fileName.contains(".py")
---
 ```

- Failed to obtain ClassStructure and add StructureProvider to load language-specific providers dynamically