### PR TITLE
fix: Add ShirePluginDisposable to eliminate warnings about memory leaks

### DIFF
--- a/shirelang/src/main/kotlin/com/phodal/shirelang/run/ShirePluginDisposable.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/run/ShirePluginDisposable.kt
@@ -1,0 +1,32 @@
+package com.phodal.shirelang.run
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+
+/**
+ * The service is a parent disposable that represents the entire plugin lifecycle
+ * and is intended to be used instead of the project/application as a parent disposable,
+ * ensures that disposables registered using it as parents will be processed when the plugin is unloaded to avoid memory leaks.
+ *
+ * @author lk
+ */
+@Service(Service.Level.APP, Service.Level.PROJECT)
+class ShirePluginDisposable : Disposable {
+
+    override fun dispose() {
+    }
+
+    companion object {
+
+        fun getInstance(): ShirePluginDisposable {
+            return ApplicationManager.getApplication().getService(ShirePluginDisposable::class.java)
+        }
+
+        fun getInstance(project: Project): ShirePluginDisposable {
+            return project.getService(ShirePluginDisposable::class.java)
+        }
+
+    }
+}

--- a/shirelang/src/main/kotlin/com/phodal/shirelang/run/ShireProgramRunner.kt
+++ b/shirelang/src/main/kotlin/com/phodal/shirelang/run/ShireProgramRunner.kt
@@ -12,6 +12,7 @@ import com.intellij.execution.runners.showRunContent
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.util.Disposer
 import java.util.concurrent.atomic.AtomicReference
 
 class ShireProgramRunner : GenericProgramRunner<RunnerSettings>(), Disposable {
@@ -20,6 +21,10 @@ class ShireProgramRunner : GenericProgramRunner<RunnerSettings>(), Disposable {
     private val connection = ApplicationManager.getApplication().messageBus.connect(this)
 
     private var isSubscribed = false
+
+    init {
+        Disposer.register(ShirePluginDisposable.getInstance(), this)
+    }
 
     override fun getRunnerId(): String = RUNNER_ID
 


### PR DESCRIPTION
`ShireProgramRunner` does not have any parent disposable, leading to potential memory leaks,
It should be registered to a parent disposable with the same life cycle as the plugin.