### PR TITLE
Add metrics to PsiContext

### DIFF
--- a/core/src/main/kotlin/com/phodal/shirecore/middleware/PostProcessor.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/middleware/PostProcessor.kt
@@ -37,6 +37,9 @@ interface PostProcessor {
      * Some init tasks, like metric for time, etc.
      */
     fun setup(context: PostProcessorContext): Any {
+        context.changeCount = 0
+        context.lineCount = 0
+        context.complexityCount = 0
         return ""
     }
 
@@ -54,6 +57,7 @@ interface PostProcessor {
      * Clean up tasks, like metric for time, etc.
      */
     fun finish(context: PostProcessorContext): Any? {
+        // Implement logic to finalize changeCount, lineCount, and complexityCount metrics
         return ""
     }
 

--- a/core/src/main/kotlin/com/phodal/shirecore/middleware/PostProcessorContext.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/middleware/PostProcessorContext.kt
@@ -56,6 +56,21 @@ class PostProcessorContext(
     var compiledVariables: Map<String, Any?> = mapOf(),
 
     val llmModelName: String? = null,
+
+    /**
+     * The number of changes made
+     */
+    var changeCount: Int = 0,
+
+    /**
+     * The number of lines in the code
+     */
+    var lineCount: Int = 0,
+
+    /**
+     * The complexity of the code
+     */
+    var complexityCount: Int = 0,
 ) {
     companion object {
         private val DATA_KEY: Key<PostProcessorContext> = Key.create(PostProcessorContext::class.java.name)

--- a/core/src/main/kotlin/com/phodal/shirecore/middleware/PostProcessorType.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/middleware/PostProcessorType.kt
@@ -90,5 +90,19 @@ enum class PostProcessorType(var handleName: String) {
 
     // showWebView
     ShowWebview("showWebView"),
-    ;
+
+    /**
+     * Metric change count.
+     */
+    ChangeCountMetric("changeCountMetric"),
+
+    /**
+     * Metric line count.
+     */
+    LineCountMetric("lineCountMetric"),
+
+    /**
+     * Metric complexity count.
+     */
+    ComplexityMetric("complexityMetric"),
 }

--- a/core/src/main/kotlin/com/phodal/shirecore/provider/variable/impl/DefaultPsiContextVariableProvider.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/variable/impl/DefaultPsiContextVariableProvider.kt
@@ -6,6 +6,9 @@ import com.intellij.psi.PsiElement
 import com.phodal.shirecore.provider.variable.PsiContextVariableProvider
 import com.phodal.shirecore.provider.variable.model.PsiContextVariable
 import com.phodal.shirecore.provider.variable.model.PsiContextVariable.FRAMEWORK_CONTEXT
+import com.phodal.shirecore.provider.variable.model.PsiContextVariable.CHANGE_COUNT
+import com.phodal.shirecore.provider.variable.model.PsiContextVariable.LINE_COUNT
+import com.phodal.shirecore.provider.variable.model.PsiContextVariable.COMPLEXITY_COUNT
 
 class DefaultPsiContextVariableProvider : PsiContextVariableProvider {
     override fun resolve(variable: PsiContextVariable, project: Project, editor: Editor, psiElement: PsiElement?): String {
@@ -13,7 +16,18 @@ class DefaultPsiContextVariableProvider : PsiContextVariableProvider {
             FRAMEWORK_CONTEXT -> {
                 return collectFrameworkContext(psiElement, project)
             }
-
+            CHANGE_COUNT -> {
+                // Implement logic to calculate change count
+                return "0" // Placeholder value
+            }
+            LINE_COUNT -> {
+                // Implement logic to calculate line count
+                return "0" // Placeholder value
+            }
+            COMPLEXITY_COUNT -> {
+                // Implement logic to calculate complexity count
+                return "0" // Placeholder value
+            }
             else -> ""
         }
     }

--- a/core/src/main/kotlin/com/phodal/shirecore/provider/variable/model/PsiContextVariable.kt
+++ b/core/src/main/kotlin/com/phodal/shirecore/provider/variable/model/PsiContextVariable.kt
@@ -76,7 +76,22 @@ enum class PsiContextVariable(
 
     SIMILAR_CODE("similarCode", "Recently 20 files similar code based on the tf-idf search"),
 
-    STRUCTURE("structure", "The structure of the current class, for programming language will be in UML format.")
+    STRUCTURE("structure", "The structure of the current class, for programming language will be in UML format."),
+
+    /**
+     * Represents the number of changes made.
+     */
+    CHANGE_COUNT("changeCount", "The number of changes made"),
+
+    /**
+     * Represents the number of lines in the code.
+     */
+    LINE_COUNT("lineCount", "The number of lines in the code"),
+
+    /**
+     * Represents the complexity of the code.
+     */
+    COMPLEXITY_COUNT("complexityCount", "The complexity of the code")
     ;
 
     companion object {


### PR DESCRIPTION
Related to #139

Add support for metrics in PsiContext.

* **PsiContextVariable.kt**: Add new enum constants `CHANGE_COUNT`, `LINE_COUNT`, and `COMPLEXITY_COUNT` with descriptions.
* **DefaultPsiContextVariableProvider.kt**: Implement logic to resolve `CHANGE_COUNT`, `LINE_COUNT`, and `COMPLEXITY_COUNT` variables with placeholder values.
* **PostProcessorContext.kt**: Add properties `changeCount`, `lineCount`, and `complexityCount` to the `PostProcessorContext` class.
* **PostProcessor.kt**: Initialize `changeCount`, `lineCount`, and `complexityCount` in the `setup` method and add a placeholder for finalizing these metrics in the `finish` method.
* **PostProcessorType.kt**: Add new enum constants `ChangeCountMetric`, `LineCountMetric`, and `ComplexityMetric`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/shire/pull/140?shareId=f50fcc6a-4d1e-46d5-84b1-2801a2bc81ba).